### PR TITLE
Fixing Bug - Unicode character in tab number shouldn't return 500

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -216,3 +216,4 @@ Randy Ostler <rando305@gmail.com>
 Thomas Young <thomas@upcoder.com>
 Andrew Dekker <simultech@gmail.com>
 Christopher Lee <clee@edx.org>
+Mushtaq Ali <mushtaque.ali@arbisoft.com>

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -262,7 +262,6 @@ class ViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(request_url)
         self.assertEqual(response.status_code, 404)
 
-    @unittest.skip
     def test_unicode_handling_in_url(self):
         url_parts = [
             '/courses',

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -364,7 +364,7 @@ def _index_bulk_op(request, course_key, chapter, section, position):
         try:
             int(position)
         except ValueError:
-            raise Http404("Position {} is not an integer!".format(position))
+            raise Http404(u"Position {} is not an integer!".format(position))
 
     user = request.user
     course = get_course_with_access(user, 'load', course_key, depth=2)


### PR DESCRIPTION
TNL-2055 - Unicode character in tab number shouldn't return 500.

For edX pages that have multiple tabs (like [this one](https://courses.edx.org/courses/edX/DemoX.1/2014/courseware/0af8db2309474971bfa70cda98668a30/9c1aacbb2795470e8473b059b59c3344/)), you can add a number to the end of the url to specify which tab the page should open on. Otherwise the last tab you saw will show up, or if you haven't seen the page before, the first tab will show up. 

So if you go to https://courses.edx.org/courses/edX/DemoX.1/2014/courseware/0af8db2309474971bfa70cda98668a30/9c1aacbb2795470e8473b059b59c3344/2, you'll go to the second tab. 

However the bug emerges when you add a special unicode character ( ex : "%E2%80%9C" ) to the end of a url instead of a number. 

The bug emerged due to formatting string with special unicode character outside range(128). So we should use u\ unicode string instead of normal string in "Http404('Position {} is not an integer!'.format(position)) " message 
